### PR TITLE
Reset pause state

### DIFF
--- a/src/components/Recorder.js
+++ b/src/components/Recorder.js
@@ -13,7 +13,6 @@ class Recorder extends Component {
     this.state = {
       time: {},
       seconds: 0,
-      isPaused: false,
       recording: false,
       medianotFound: false,
       audios: [],
@@ -121,7 +120,6 @@ class Recorder extends Component {
     this.setState({
       time: {},
       seconds: 0,
-      isPaused: false,
       recording: false,
       medianotFound: false,
       audios: [],

--- a/src/components/Recorder.js
+++ b/src/components/Recorder.js
@@ -108,7 +108,7 @@ class Recorder extends Component {
     // stop the recorder
     this.mediaRecorder.stop();
     // say that we're not recording
-    this.setState({ recording: false });
+    this.setState({ recording: false, pauseRecord: false, });
     // save the video to memory
     this.saveAudio();
   }


### PR DESCRIPTION
When user click on pause button while recording, then clicking on stop button, pause state will not reset to it's default, so if user clears and start recording again, play icon displays instead of pause icon.